### PR TITLE
Update to replicated CLI 0.27.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM replicated/vendor-cli:0.23.0
+FROM replicated/vendor-cli:0.27.0
 
 ENTRYPOINT ["/bin/sh", "-c"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: replicatedhq/action-kots-lint@v0.1.0
+    - uses: replicatedhq/action-kots-lint@v0.2.0
       name: Lint the release manifests
       with:
         replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}


### PR DESCRIPTION
Update to replicated-cli 0.27.0, which introduces a new version of the linter. Update the recommended version to 0.2.0, which should be tagged off this change.